### PR TITLE
ci: fix bazel setup and macOS 14.0 availability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,12 @@
 # Swift
-*.swift linguist-language=Swift
+*.swift linguist-language=Swift linguist-detectable=true
 *.h linguist-language=Swift
 
 # Documentation
 *.md linguist-documentation
 docs/* linguist-documentation
+site/* linguist-documentation
+*.html linguist-documentation
 
 # Generated files
 *.generated.swift linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Swift
+*.swift linguist-language=Swift
+*.h linguist-language=Swift
+
+# Documentation
+*.md linguist-documentation
+docs/* linguist-documentation
+
+# Generated files
+*.generated.swift linguist-generated=true
+bazel-* linguist-generated=true
+
+# Vendored code
+vendor/* linguist-vendored=true
+external/* linguist-vendored=true
+
+# Build files
+*.bazel linguist-language=Starlark
+*.bzl linguist-language=Starlark
+WORKSPACE linguist-language=Starlark
+BUILD linguist-language=Starlark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
         # Create coverage directory
         mkdir -p coverage
         
-        # Find coverage file from bazel-out
-        COVERAGE_FILE=$(find bazel-out -name "coverage.dat")
+        # Find coverage file from _coverage/_coverage_report.dat
+        COVERAGE_FILE=$(find bazel-testlogs -name "_coverage_report.dat")
         if [ -f "$COVERAGE_FILE" ]; then
           echo "Found coverage file at: $COVERAGE_FILE"
           cp "$COVERAGE_FILE" coverage/lcov.info
@@ -96,8 +96,8 @@ jobs:
           head -n 5 coverage/lcov.info
         else
           echo "Error: Coverage file not found"
-          echo "Searching for any .dat files in bazel-out:"
-          find bazel-out -type f -name "*.dat" -ls
+          echo "Searching for any coverage files:"
+          find bazel-testlogs -type f -name "*coverage*.dat" -ls
           exit 1
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,23 +88,15 @@ jobs:
         # Create coverage directory
         mkdir -p coverage
         
-        # Find coverage file from bazel-out/_coverage
-        COVERAGE_DIR="bazel-out/_coverage"
-        if [ -d "$COVERAGE_DIR" ]; then
-          echo "Found coverage directory at: $COVERAGE_DIR"
-          COVERAGE_FILE="$COVERAGE_DIR/_coverage_report.dat"
-          if [ -f "$COVERAGE_FILE" ]; then
-            echo "Found coverage file at: $COVERAGE_FILE"
-            cp "$COVERAGE_FILE" coverage/lcov.info
-            echo "Coverage file contents:"
-            head -n 5 coverage/lcov.info
-          else
-            echo "Error: Coverage file not found in $COVERAGE_DIR"
-            ls -la "$COVERAGE_DIR"
-            exit 1
-          fi
+        # Find coverage file in bazel-out/_coverage
+        COVERAGE_FILE="$(pwd)/bazel-out/_coverage/_coverage_report.dat"
+        if [ -f "$COVERAGE_FILE" ]; then
+          echo "Found coverage file at: $COVERAGE_FILE"
+          cp "$COVERAGE_FILE" coverage/lcov.info
+          echo "Coverage file contents:"
+          head -n 5 coverage/lcov.info
         else
-          echo "Error: Coverage directory not found"
+          echo "Error: Coverage file not found at $COVERAGE_FILE"
           echo "Searching for any coverage files:"
           find bazel-out -type f -name "*coverage*.dat" -ls
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,16 +79,25 @@ jobs:
           --combined_report=lcov \
           --test_env=UMBRA_TEST_ROOT
         
-        # Ensure coverage file exists and copy it to a known location
+        # Create coverage directory and ensure it exists
         mkdir -p coverage
-        find "$(bazel info output_path)/_coverage" -name "coverage.dat" -exec cp {} coverage/coverage.dat \;
+        
+        # Find and copy the coverage file, showing debug info
+        echo "Looking for coverage files in $(bazel info output_path)/_coverage"
+        find "$(bazel info output_path)/_coverage" -name "coverage.dat" -ls
+        find "$(bazel info output_path)/_coverage" -name "coverage.dat" -exec cp {} coverage/lcov.info \;
+        
+        # Verify the coverage file exists and show its contents
+        ls -la coverage/
+        head -n 5 coverage/lcov.info
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v4
       with:
-        files: coverage/coverage.dat
+        files: coverage/lcov.info
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
+        slug: mpy-dev-ml/UmbraCore
 
     - name: Cleanup
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 permissions:
   contents: read
   security-events: write
-  id-token: write
+  id-token: read
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       run: |
         # Generate coverage data
         bazel coverage //... \
+          --collect_code_coverage \
           --instrument_test_targets \
           --experimental_generate_llvm_lcov \
           --combined_report=lcov \
@@ -95,6 +96,7 @@ jobs:
           head -n 5 coverage/lcov.info
         else
           echo "Error: Coverage file not found"
+          echo "Searching for any .dat files in bazel-out:"
           find bazel-out -type f -name "*.dat" -ls
           exit 1
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  BAZEL_VERSION: 8.1.0
+  BAZEL_VERSION: v8.1.0
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
   SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       uses: bazel-contrib/setup-bazel@0.8.0
       with:
         bazelrc: .bazelrc
-        version: ${{ env.BAZEL_VERSION }}
+        bazelisk-version: ${{ env.BAZEL_VERSION }}
 
     - name: Configure Bazel
       run: |
@@ -100,4 +100,5 @@ jobs:
     - name: Cleanup
       if: always()
       run: |
-        rm -rf ~/UmbraTest coverage
+        rm -rf ~/UmbraTest
+        bazel clean --expunge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,14 @@ jobs:
           --experimental_generate_llvm_lcov \
           --combined_report=lcov \
           --test_env=UMBRA_TEST_ROOT \
-          --verbose_failures
+          --verbose_failures \
+          --test_output=errors
         
         # Create coverage directory
         mkdir -p coverage
         
-        # Find coverage file and copy it
-        COVERAGE_FILE=$(find "$(bazel info output_path)" -name "coverage.dat")
+        # Find coverage file from bazel-out
+        COVERAGE_FILE=$(find bazel-out -name "coverage.dat")
         if [ -f "$COVERAGE_FILE" ]; then
           echo "Found coverage file at: $COVERAGE_FILE"
           cp "$COVERAGE_FILE" coverage/lcov.info
@@ -94,6 +95,7 @@ jobs:
           head -n 5 coverage/lcov.info
         else
           echo "Error: Coverage file not found"
+          find bazel-out -type f -name "*.dat" -ls
           exit 1
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,22 +74,28 @@ jobs:
       env:
         UMBRA_TEST_ROOT: ~/UmbraTest/Coverage
       run: |
+        # Generate coverage data
         bazel coverage //... \
+          --instrument_test_targets \
           --experimental_generate_llvm_lcov \
           --combined_report=lcov \
-          --test_env=UMBRA_TEST_ROOT
+          --test_env=UMBRA_TEST_ROOT \
+          --verbose_failures
         
-        # Create coverage directory and ensure it exists
+        # Create coverage directory
         mkdir -p coverage
         
-        # Find and copy the coverage file, showing debug info
-        echo "Looking for coverage files in $(bazel info output_path)/_coverage"
-        find "$(bazel info output_path)/_coverage" -name "coverage.dat" -ls
-        find "$(bazel info output_path)/_coverage" -name "coverage.dat" -exec cp {} coverage/lcov.info \;
-        
-        # Verify the coverage file exists and show its contents
-        ls -la coverage/
-        head -n 5 coverage/lcov.info
+        # Find coverage file and copy it
+        COVERAGE_FILE=$(find "$(bazel info output_path)" -name "coverage.dat")
+        if [ -f "$COVERAGE_FILE" ]; then
+          echo "Found coverage file at: $COVERAGE_FILE"
+          cp "$COVERAGE_FILE" coverage/lcov.info
+          echo "Coverage file contents:"
+          head -n 5 coverage/lcov.info
+        else
+          echo "Error: Coverage file not found"
+          exit 1
+        fi
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-  workflow_dispatch:
-  push:
-    branches: [ main, feature/ci-improvements ]
-  pull_request_target:
-    branches: [ main ]
-    types: [opened, synchronize, reopened]
+on: [push, pull_request]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,16 @@ env:
   SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 
 permissions:
-  contents: read
+  contents: write
   security-events: write
-  id-token: read
+  id-token: write
+  checks: write
+  pull-requests: write
 
 jobs:
   build-and-test:
     name: Build & Test
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, ARM64]
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           --collect_code_coverage \
           --instrument_test_targets \
           --experimental_generate_llvm_lcov \
+          --coverage_report_generator=@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main \
           --combined_report=lcov \
           --test_env=UMBRA_TEST_ROOT \
           --verbose_failures \
@@ -98,6 +99,8 @@ jobs:
           echo "Error: Coverage file not found"
           echo "Searching for any coverage files:"
           find bazel-testlogs -type f -name "*coverage*.dat" -ls
+          echo "Searching in bazel-out:"
+          find bazel-out -type f -name "*coverage*.dat" -ls
           exit 1
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         cat >> .bazelrc << 'EOF'
         build --cpu=darwin_arm64
         build --apple_platform_type=macos
-        build --macos_minimum_os=13.0
+        build --macos_minimum_os=14.0
         build --features=swift.use_global_module_cache
         build --features=swift.enable_batch_mode
         build --features=swift.enable_concurrency_checking
@@ -85,15 +85,19 @@ jobs:
           --experimental_generate_llvm_lcov \
           --combined_report=lcov \
           --test_env=UMBRA_TEST_ROOT
+        
+        # Ensure coverage file exists and copy it to a known location
+        mkdir -p coverage
+        find "$(bazel info output_path)/_coverage" -name "coverage.dat" -exec cp {} coverage/coverage.dat \;
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v4
       with:
-        files: $(bazel info output_path)/_coverage/_coverage_report.dat
+        files: coverage/coverage.dat
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Cleanup
       if: always()
       run: |
-        rm -rf ~/UmbraTest
+        rm -rf ~/UmbraTest coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, feature/ci-improvements ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
+    types: [opened, synchronize, reopened]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,18 +88,24 @@ jobs:
         # Create coverage directory
         mkdir -p coverage
         
-        # Find coverage file from _coverage/_coverage_report.dat
-        COVERAGE_FILE=$(find bazel-testlogs -name "_coverage_report.dat")
-        if [ -f "$COVERAGE_FILE" ]; then
-          echo "Found coverage file at: $COVERAGE_FILE"
-          cp "$COVERAGE_FILE" coverage/lcov.info
-          echo "Coverage file contents:"
-          head -n 5 coverage/lcov.info
+        # Find coverage file from bazel-out/_coverage
+        COVERAGE_DIR="bazel-out/_coverage"
+        if [ -d "$COVERAGE_DIR" ]; then
+          echo "Found coverage directory at: $COVERAGE_DIR"
+          COVERAGE_FILE="$COVERAGE_DIR/_coverage_report.dat"
+          if [ -f "$COVERAGE_FILE" ]; then
+            echo "Found coverage file at: $COVERAGE_FILE"
+            cp "$COVERAGE_FILE" coverage/lcov.info
+            echo "Coverage file contents:"
+            head -n 5 coverage/lcov.info
+          else
+            echo "Error: Coverage file not found in $COVERAGE_DIR"
+            ls -la "$COVERAGE_DIR"
+            exit 1
+          fi
         else
-          echo "Error: Coverage file not found"
+          echo "Error: Coverage directory not found"
           echo "Searching for any coverage files:"
-          find bazel-testlogs -type f -name "*coverage*.dat" -ls
-          echo "Searching in bazel-out:"
           find bazel-out -type f -name "*coverage*.dat" -ls
           exit 1
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build & Test
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: self-hosted
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, feature/ci-improvements ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
     branches: [ main ]
 
 env:
-  BAZEL_VERSION: v8.1.0
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
   SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 
@@ -32,12 +31,6 @@ jobs:
         uname -a
         swift --version
         bazel --version
-
-    - name: Setup Bazel
-      uses: bazel-contrib/setup-bazel@0.8.0
-      with:
-        bazelrc: .bazelrc
-        bazelisk-version: ${{ env.BAZEL_VERSION }}
 
     - name: Configure Bazel
       run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UmbraCore
 
 [![CI](https://github.com/mpy-dev-ml/UmbraCore/actions/workflows/ci.yml/badge.svg)](https://github.com/mpy-dev-ml/UmbraCore/actions/workflows/ci.yml)
-[![CD](https://github.com/mpy-dev-ml/UmbraCore/actions/workflows/cd.yml/badge.svg)](https://github.com/mpy-dev-ml/UmbraCore/actions/workflows/cd.yml)
+[![Documentation](https://github.com/mpy-dev-ml/UmbraCore/actions/workflows/docs.yml/badge.svg)](https://github.com/mpy-dev-ml/UmbraCore/actions/workflows/docs.yml)
 [![codecov](https://codecov.io/gh/mpy-dev-ml/UmbraCore/branch/main/graph/badge.svg)](https://codecov.io/gh/mpy-dev-ml/UmbraCore)
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-blue.svg)](https://mpy-dev-ml.github.io/UmbraCore/)
 

--- a/Sources/Features/Logging/Services/LoggingService.swift
+++ b/Sources/Features/Logging/Services/LoggingService.swift
@@ -3,7 +3,8 @@ import SecurityTypes
 import UmbraTestKit
 
 /// Service for managing log files with security-scoped bookmarks
-public actor LoggingService {
+@available(macOS 14.0, *)
+public actor LoggingService: Sendable {
     /// Shared instance with default security service
     public static let shared = LoggingService(securityProvider: MockSecurityProvider())
 
@@ -80,7 +81,10 @@ public actor LoggingService {
     ///   - path: Path to the log file
     ///   - operation: Operation to perform while accessing the file
     /// - Returns: Result of the operation
-    public func withSecurityScopedLogAccess<T>(to path: String, perform operation: () async throws -> T) async throws -> T {
+    public func withSecurityScopedLogAccess<T: Sendable>(
+        to path: String,
+        perform operation: @Sendable () async throws -> T
+    ) async throws -> T {
         try await securityProvider.withSecurityScopedAccess(to: path, perform: operation)
     }
 }

--- a/Sources/UmbraKeychainService/KeychainXPCService.swift
+++ b/Sources/UmbraKeychainService/KeychainXPCService.swift
@@ -119,6 +119,7 @@ extension KeychainXPCProtocol {
     }
 }
 
+@available(macOS 14.0, *)
 final class KeychainXPCService: NSObject {
     private(set) var listener: NSXPCListener
     private let exportedObject: KeychainXPCProtocol


### PR DESCRIPTION
# CI/CD and Swift 6 Compatibility Improvements

## Changes

### CI/CD Improvements
- Updated Bazel setup action to use bazelisk-version parameter
- Enhanced cleanup step in CI workflow
- Removed BuildBuddy integration
- Updated workflow permissions and runner configuration
- Fixed CI workflow startup issues

### Swift 6 Compatibility
- Added @available(macOS 14.0, *) attribute to KeychainXPCService
- Added @Sendable conformance to LoggingService actor
- Made generic type parameter Sendable in withSecurityScopedLogAccess
- Added @Sendable to async closures in URLSecurityTests
- Made test methods nonisolated in URLSecurityTests

### Documentation
- Updated .gitattributes for better language detection
- Marked site directory and HTML files as documentation

## Testing
- All core tests pass
- All security tests pass
- Coverage reports generated and uploaded to Codecov